### PR TITLE
Added note about 256 colours to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Paste below command in your `~/.vimrc`:
     syntax on
     colorscheme monokai
 
+vim-monokai requires 256 colors. You may need to add this before `syntax on` to enable the scheme:
+
+	set t_Co=256
+
 Configuration
 -------------
 


### PR DESCRIPTION
I had some trouble getting the colour scheme to kick in, then realised you need to set 256 colours before it will work. (Scenario was setting up vim on a raspberry pi, if that matters :))

Perhaps it's common knowledge, perhaps not, figured it doesn't hurt to put it in the readme.