### PR TITLE
fix: Make diff highlighting show up 

### DIFF
--- a/colors/monokai.vim
+++ b/colors/monokai.vim
@@ -92,7 +92,8 @@ let s:darkred     = { "gui": "#5f0000", "cterm": "52" }
 
 let s:addfg       = { "gui": "#d7ffaf", "cterm": "193" }
 let s:addbg       = { "gui": "#5f875f", "cterm": "65" }
-let s:delbg       = { "gui": "#f75f5f", "cterm": "167" }
+let s:delfg       = { "gui": "#ff8b8b", "cterm": "210" }
+let s:delbg       = { "gui": "#f75f5f", "cterm": "124" }
 let s:changefg    = { "gui": "#d7d7ff", "cterm": "189" }
 let s:changebg    = { "gui": "#5f5f87", "cterm": "60" }
 

--- a/colors/monokai.vim
+++ b/colors/monokai.vim
@@ -143,7 +143,7 @@ call s:h("Directory",     { "fg": s:aqua })
 
 " diff
 call s:h("DiffAdd",       { "fg": s:addfg,      "bg": s:addbg })
-call s:h("DiffDelete",    { "fg": s:black,      "bg": s:delbg })
+call s:h("DiffDelete",    { "fg": s:delfg,      "bg": s:delbg })
 call s:h("DiffChange",    { "fg": s:changefg,   "bg": s:changebg })
 call s:h("DiffText",      { "fg": s:black,      "bg": s:aqua })
 


### PR DESCRIPTION
Some plugins I use disable the bg settings for the diff view. When `DiffDelete` foreground is set to black, this causes the text to effectively become invisible. Also, the delete coloring is inconsistent with the added coloring.

I've added a new `delfg` color setting and added that to the `DiffDelete` specification.

Before:
![image](https://user-images.githubusercontent.com/20801821/89679640-c50b9080-d8ae-11ea-9bef-63e3653f85b1.png)

After:
![image](https://user-images.githubusercontent.com/20801821/89679578-a1484a80-d8ae-11ea-8ef5-87225af41f43.png)
