### PR TITLE
Revert "improvement: coc.nvim rename word highlight"

### DIFF
--- a/colors/monokai.vim
+++ b/colors/monokai.vim
@@ -250,10 +250,6 @@ call s:h("CocInfoHighlight",        { "format": "underline" })
 call s:h("CocHintSign",             { "fg": s:white, "bg": s:lightblack3 })
 call s:h("CocHintHighlight",        { "format": "underline" })
 
-call s:h("CocHighlightText",        { "fg": s:aqua })
-" document.renameCurrentWord cursor word highlight
-call s:h("CocCursorRange",          { "fg": s:warmgrey, "bg": s:yellow })
-
 " Language highlight
 " ------------------
 


### PR DESCRIPTION
This reverts commit 65fa0678d8426ae2cc7a4c42a8f0d72bde2a7bbe.

Closes #40 